### PR TITLE
Fix: Initial project cleanup, build fixes, and documentation updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # Roadrunner Project
 
 > **Important Note on Project Structure:**
-> The `roadrunner/` directory contains the components of a **standalone  Electron application (frontend in `roadrunner/frontend/`, main process in `roadrunner/electron.js`) and its backend server (`roadrunner/backend/`).** While the `TokomakAI.Desktop/` application is the primary focus for new development, the `roadrunner/backend/` is being stabilized to support this standalone  `roadrunner/` application. Its core logic and agents (fsAgent, gitAgent) have informed the `TokomakCore/roadrunnercore` module, which serves as the backend for Roadrunner features integrated within `TokomakAI.Desktop`.
-> Task definition for this  application is via UI inputs for a task goal and a sequence of steps.
-> The primary, actively developed user interface for this project is now **`TokomakAI.Desktop/`**, which is a separate Electron application.
-> Please refer to the main project `README.md` (in the root directory) for the overall architecture and instructions for running the current application.
+> The `roadrunner/` directory contains the components of a **standalone Electron application (frontend in `roadrunner/frontend/`, main process in `roadrunner/electron.js`) and its backend server (`roadrunner/backend/`).** The `roadrunner/backend/` is stabilized to support this standalone `roadrunner/` application, which is developed and maintained independently. Its core logic and agents (fsAgent, gitAgent) have informed the `TokomakCore/roadrunnercore` module, which serves as the backend for Roadrunner features integrated within `TokomakAI.Desktop`.
+> Task definition for this application is via UI inputs for a task goal and a sequence of steps.
+> This README focuses on the standalone Roadrunner application within the `roadrunner/` directory. (Information about `TokomakAI.Desktop` and `TokomakCore/roadrunnercore` is for context on shared lineage only).
 
 The newer `roadrunnercore` module within `TokomakCore/` repurposes this application's backend logic so that TokomakAI Desktop can offer the same Roadrunner features internally. When users open the Roadrunner panel from the Toko32 dashboard, the desktop app launches its own copy of this frontend in a modal while communicating with `roadrunnercore` rather than this standalone server. Despite sharing code, the standalone `roadrunner/` app and the integrated `roadrunnercore` setup are maintained as separate projects.
 
-**This README primarily concerns the standalone  application components within the `roadrunner/` directory (Electron main process, Vue.js frontend, and Node.js backend).**
+**This README primarily concerns the standalone application components within the `roadrunner/` directory (Electron main process, Vue.js frontend, and Node.js backend).**
 
 ---
 
@@ -80,8 +79,6 @@ Interacting with Roadrunner typically follows these steps:
 
 ## Installation & Setup
 
-The main components to set up from the `roadrunner/` directory perspective is the backend server. The `TokomakAI.Desktop/` application is run from its own directory.
-
 1.  **Backend Server Setup (`roadrunner/backend/`)**:
     ```bash
     cd roadrunner/backend
@@ -92,27 +89,19 @@ The main components to set up from the `roadrunner/` directory perspective is th
     # See roadrunner/backend/README.md for details.
     ```
 
-2.  **Desktop Application Setup (`TokomakAI.Desktop/`)**:
-    Refer to the main project `README.md` or `TokomakAI.Desktop/README.md` for instructions on running the main UI. Typically:
-    ```bash
-    cd ../TokomakAI.Desktop # (Assuming you are in roadrunner/)
-    npm install
-    npm run electron:dev 
-    ```
+2.  **Standalone Roadrunner App Setup (`roadrunner/`)**:
+    This refers to the Electron application defined by `roadrunner/electron.js` and its frontend in `roadrunner/frontend/`.
 
-    3.  **Standalone  Roadrunner App Setup (`roadrunner/`)**:
-        This refers to the Electron application defined by `roadrunner/electron.js` and its frontend in `roadrunner/frontend/`.
+    *   **Prerequisite:** Ensure the **Backend Server** (see point 1 above, `roadrunner/backend/server.js`) is running, as this standalone application relies on it (e.g., for loading AI models via `http://127.0.0.1:3030`).
+    *   **Running the app:**
+        Navigate to the `roadrunner` directory (i.e., the root of this project) and run:
+        ```bash
+        # Install dependencies (if first time or after changes)
+        npm install
 
-        *   **Prerequisite:** Ensure the **Backend Server** (see point 1 above, `roadrunner/backend/server.js`) is running, as this standalone application relies on it (e.g., for loading AI models via `http://127.0.0.1:3030`).
-        *   **Running the app:**
-            Navigate to the `roadrunner` directory and run:
-            ```bash
-            # Install dependencies (if first time or after changes)
-            npm install
-
-            # Build the frontend and launch the Electron app
-            npm start
-            ```
+        # Build the frontend and launch the Electron app
+        npm start
+        ```
 
 **Configuration**:
 *   **Backend**: Refer to the `roadrunner/backend/README.md` for detailed instructions on path configuration and other settings.
@@ -121,10 +110,10 @@ The main components to set up from the `roadrunner/` directory perspective is th
 
 ## ⚠️ Current Status & Disclaimer
 
-**The `roadrunner/` application (frontend, Electron main process, and backend) is a standalone  application. The `roadrunner/backend/` is being stabilized for this purpose, and its core components have informed the `TokomakCore/roadrunnercore` module, which provides Roadrunner functionalities within the modern `TokomakAI.Desktop` application.**
+**The `roadrunner/` application (frontend, Electron main process, and backend) is a standalone application. The `roadrunner/backend/` is being stabilized for this purpose, and its core components have informed the `TokomakCore/roadrunnercore` module, which provides Roadrunner functionalities within the modern `TokomakAI.Desktop` application.**
 
 - The vision of a fully autonomous AI agent is a work in progress.
-- **Core Features Implemented:** UI for task definition, backend for step-based execution, LLM integration with streaming, filesystem operations (within `roadrunner/output/` and configurable external roots) with safety guardrails and backups, Git integration for basic commands, step chaining, and a task interruption/confirmation flow (currently auto-denied by the  UI).
+- **Core Features Implemented:** UI for task definition, backend for step-based execution, LLM integration with streaming, filesystem operations (within `roadrunner/output/` and configurable external roots) with safety guardrails and backups, Git integration for basic commands, step chaining, and a task interruption/confirmation flow (currently auto-denied by the UI).
 - **Areas for Future Development:** More advanced autonomous decision-making by the LLM, complex Git workflows, UI enhancements for specific step types and confirmation handling, robust error recovery, and user-configurable settings.
 - The application's UI and backend are evolving. While the `/execute-autonomous-task` endpoint is the focus, older endpoints like `/run` may not be fully functional with recent streaming-focused refactoring of LLM utilities.
 
@@ -134,9 +123,6 @@ Use with curiosity and for local development tasks. It is not yet a production-r
 
 ## Known Issues / Non-Functioning Features
 
-*   **Project Build Failure:**
-    *   The project currently fails to build due to issues with `npm install` and Node.js module resolution in the build environment. The Vite build process cannot locate its required dependencies (e.g., `vite`, `@vitejs/plugin-vue`) even after they are seemingly downloaded by `npm install`.
-    *   This prevents the frontend from being built (`frontend/dist/` is not generated) and therefore the standalone Electron application cannot be run or tested.
 *   **Legacy `/run` Endpoint:**
     *   As noted in the 'Current Status & Disclaimer', the older `/run` backend endpoint (related to previous component generation functionality) may not be fully functional with recent refactoring of LLM utilities. The primary focus for task execution is the `/execute-autonomous-task` endpoint.
 

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,1 +1,2 @@
 .env
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "marked": "^12.0.2",
-        "vue": "^3.4.0"
+        "vue": "^3.4.0",
+        "vuex": "^4.1.0"
       },
       "devDependencies": {
         "@babel/core": "^7.27.4",
@@ -3686,6 +3687,11 @@
         "@vue/compiler-dom": "3.5.16",
         "@vue/shared": "3.5.16"
       }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g=="
     },
     "node_modules/@vue/reactivity": {
       "version": "3.5.16",
@@ -9298,6 +9304,17 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vuex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-4.1.0.tgz",
+      "integrity": "sha512-hmV6UerDrPcgbSy9ORAtNXDr9M4wlNP4pEFKye4ujJF8oqgFFuxDCdOLS3eNoRTtq5O3hoBDh9Doj1bQMYHRbQ==",
+      "dependencies": {
+        "@vue/devtools-api": "^6.0.0-beta.11"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
       }
     },
     "node_modules/walker": {

--- a/package.json
+++ b/package.json
@@ -5,14 +5,15 @@
   "scripts": {
     "dev": "npx vite",
     "build": "npx vite build",
-    "start": "npm run build && .\\node_modules\\.bin\\electron.cmd electron.js",
+    "start": "npm run build && npx electron .",
     "preview": "npx vite preview",
     "test": "jest",
     "electron": "electron ."
   },
   "dependencies": {
     "marked": "^12.0.2",
-    "vue": "^3.4.0"
+    "vue": "^3.4.0",
+    "vuex": "^4.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.27.4",


### PR DESCRIPTION
This commit addresses several key issues to make the Roadrunner standalone project buildable, runnable, and more clearly documented.

Key changes include:

1.  **Frontend Build Fixed:**
    *   I identified that the frontend build was failing due to a missing `vuex` dependency.
    *   I added `vuex` to `package.json` (version `^4.1.0`), resolving the build errors.
    *   I verified that `npm run build` now successfully generates the frontend assets in `frontend/dist/`.

2.  **Backend Server Verified:**
    *   I ensured backend dependencies install correctly via `npm install` in the `backend/` directory.
    *   I confirmed the backend server starts successfully using `npm start` and is responsive via a `/health` check.

3.  **Electron App Launch Verified:**
    *   I confirmed the Electron application launches via `npm start` after a successful frontend build.

4.  **`.gitignore` Updates:**
    *   I updated `backend/.gitignore` to include `node_modules/`, ensuring backend-specific dependencies are not tracked.
    *   I reviewed the root `.gitignore` and found it to be comprehensive.

5.  **Documentation (`README.md`) Overhaul:**
    *   I significantly revised `README.md` to accurately reflect the project's standalone nature.
    *   I removed misleading references to `TokomakAI.Desktop` as the primary UI.
    *   I updated the "Known Issues" section by removing the "Project Build Failure" item, as it's now resolved.
    *   I clarified installation and setup instructions for the standalone application.

6.  **`package.json` Script Improvement:**
    *   I modified the `npm start` script to use `npm run build && npx electron .` for better cross-platform compatibility, replacing the Windows-specific path to the Electron executable.

These changes complete the initial stabilization and cleanup phase. The project is now in a better state for further testing and development.