### PR TITLE
Add orange scrollbar theme

### DIFF
--- a/frontend/src/styles/roadrunner.css
+++ b/frontend/src/styles/roadrunner.css
@@ -34,6 +34,24 @@ body {
   font-size: 14px; /* Added this line */
 }
 
+/* Orange themed scrollbars for any overflow */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--theme-orange) var(--theme-orange-dark);
+}
+*::-webkit-scrollbar {
+  width: 0.5rem;
+  height: 0.5rem;
+}
+*::-webkit-scrollbar-track {
+  background: var(--theme-orange-dark);
+}
+*::-webkit-scrollbar-thumb {
+  background-color: var(--theme-orange);
+  border-radius: 0.25rem;
+  border: 2px solid var(--theme-orange-dark);
+}
+
 input[type="text"],
 textarea {
   background-color: #000000;


### PR DESCRIPTION
## Summary
- style scrollbars with the existing orange theme across the app

## Testing
- `npm test` *(fails: Cannot find module 'node-mocks-http' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68404d92d6988327b2f5680b6cc18b2a