### PR TITLE
Move App wrapper to body with transparent background

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Roadrunner Executor</title>
   </head>
-  <body class="dark text-white">
+  <body class="dark text-white tyrannidae-main-card glow-box">
     <div id="app"></div>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/frontend/src/App.spec.js
+++ b/frontend/src/App.spec.js
@@ -42,7 +42,7 @@ describe('Roadrunner App.vue', () => {
 
   it('renders the main application container', () => {
     const wrapper = mount(App);
-    expect(wrapper.find('.corvidae-app-container').exists()).toBe(true);
+    expect(wrapper.find('.furnariidae-inner-panel').exists()).toBe(true);
   });
 
   it('renders Coder tab button', () => {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,5 @@
 <template>
-  <div class="corvidae-app-container">
-    <div class="tyrannidae-main-card glow-box">
-      <div class="furnariidae-inner-panel">
+  <div class="furnariidae-inner-panel">
         <div class="accipiter-header">
           <span class="accipiter-title">Roadrunner AI Executor</span>
           <button @click="closeWindow" class="fringilla-close-button">X</button>
@@ -157,10 +155,7 @@
                    :class="['whitespace-pre-wrap', item.type === 'error' ? 'text-red-400' : (item.type === 'success' ? 'text-green-400' : 'text-gray-300')]">
                 <span class="font-mono text-xs mr-2">{{ new Date(item.timestamp).toLocaleTimeString() }}</span>
                 <span>{{ item.message }}</span>
-              </div>
-            </div>
-          </div>
-          </div>
+        </div>
         </div>
 
         <!-- Brainstorming Tab Content -->
@@ -233,9 +228,7 @@
         <!-- Settings Panel (conditionally rendered) -->
 
       </div>
-    </div>
-  </div>
-</template>
+  </template>
 
 <script>
 import RoadmapParser from './RoadmapParser';

--- a/frontend/src/styles/roadrunner.css
+++ b/frontend/src/styles/roadrunner.css
@@ -22,9 +22,13 @@
 }
 
 /* Global Element Styles */
+html {
+  background-color: black;
+}
+
 body {
   margin: 0;
-  background-color: black;
+  background-color: transparent;
   font-family: 'JetBrains Mono', monospace;
   min-height: 100vh;
   display: flex;
@@ -98,14 +102,6 @@ textarea:focus {
 /* === Bird Taxonomy Styles (App.vue & RoadrunnerExecutor.vue) === */
 
 /* Page & App Containers */
-.corvidae-app-container { /* App.vue main wrapper */
-  padding: 1rem;
-  font-family: 'JetBrains Mono', 'Share Tech Mono', 'Fira Code', monospace;
-  min-height: calc(100vh - 2rem); /* body is slightly larger */
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
 .geococcyx-executor-page { /* RoadrunnerExecutor.vue main wrapper */
   padding: 1.5rem;
   font-family: 'JetBrains Mono', 'Share Tech Mono', 'Fira Code', monospace;


### PR DESCRIPTION
## Summary
- make `<body>` act as main card
- drop extra wrapper divs from `App.vue`
- ensure body is transparent by styling `html` and `body`
- update unit test for new container class

## Testing
- `npm test` *(fails: Cannot find module 'supertest' and other packages)*

------
https://chatgpt.com/codex/tasks/task_e_68404e563c308327b36b5bb9a5e9e7b2