### PR TITLE
Fix brainstorming IPC and clean scoped styles

### DIFF
--- a/Info/brainstorming_fix.sniper.md
+++ b/Info/brainstorming_fix.sniper.md
@@ -1,0 +1,4 @@
+# Brainstorming IPC Fix
+
+## Goal
+Expose IPC helpers in `preload.js` so Vue components can access brainstorming chat features via `window.electronAPI`.

--- a/Info/brainstorming_fix.steps.md
+++ b/Info/brainstorming_fix.steps.md
@@ -1,0 +1,3 @@
+- Added `electronAPI` bridge in `preload.js` for brainstorming chat IPC.
+- Updated `electron.js` console message handler to new signature.
+- Moved Vue component scoped styles to `roadrunner.css`.

--- a/electron.js
+++ b/electron.js
@@ -28,7 +28,8 @@ function createWindow() {
     console.error(`[Main-WebContents] Renderer did-fail-load: ${validatedURL}, Code: ${errorCode}, Desc: ${errorDescription}`);
   });
 
-  mainWindow.webContents.on('console-message', (event, level, message, line, sourceId) => {
+  mainWindow.webContents.on('console-message', (event, messageInfo) => {
+    const { level, message, line, sourceId } = messageInfo;
     const levelStr = ['VERBOSE', 'INFO', 'WARNING', 'ERROR'][level] || `LEVEL${level}`;
     console.log(`[Main-WebContents-Console] [${levelStr}] ${message} (source: ${sourceId}:${line})`);
   });

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -642,12 +642,4 @@ export default {
 };
 </script>
 
-<style scoped>
-/* ... (existing styles) ... */
-.turdus-select-xs {
-  padding: 0.25rem 0.5rem;
-  font-size: 0.75rem; /* Smaller font size */
-  /* Add other styling to make it less tall if needed, e.g., height or line-height */
-}
 
-</style>

--- a/frontend/src/components/ConfigurationTab.vue
+++ b/frontend/src/components/ConfigurationTab.vue
@@ -227,29 +227,4 @@ export default {
 };
 </script>
 
-<style scoped>
-/* Copied from SettingsPanel.vue for form-group margin and input focus styling */
-.form-group {
-  margin-bottom: 20px;
-}
 
-/* Assuming hirundo-text-input provides base styling, add focus behavior */
-.hirundo-text-input:focus,
-select.hirundo-text-input:focus { /* Target select specifically if needed */
-  outline: none;
-  border-color: #4299e1; /* blue-500 */
-  box-shadow: 0 0 0 2px #4299e1; /* Focus ring */
-}
-
-/* Ensure labels in the new section have consistent styling if emberiza-label is not sufficient */
-.form-group label.emberiza-label {
-  display: block; /* Or other styling as needed if not covered by Tailwind utility */
-  margin-bottom: 8px; /* Tailwind class equivalent: mb-2 */
-  font-weight: bold; /* Tailwind class equivalent: font-bold */
-}
-
-/* The action button .cardinalis-button-action should be styled by existing global/Tailwind styles.
-   If specific overrides from .action-button of SettingsPanel are needed, they can be added here,
-   but it's generally better to adapt to the existing style system.
-*/
-</style>

--- a/frontend/src/styles/roadrunner.css
+++ b/frontend/src/styles/roadrunner.css
@@ -308,6 +308,11 @@ textarea:focus {
   box-shadow: 0 0 0 2px var(--theme-orange);
 }
 
+.turdus-select-xs {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+}
+
 .hirundo-text-input { /* RoadrunnerExecutor.vue text input/textarea */
   width: 100%; /* Uses global input/textarea styles for other properties */
 }
@@ -852,4 +857,21 @@ input#brainstormingFileUpload.turdus-select {
 
 .brainstorming-log-area {
   border-radius: 0.25rem;
+}
+
+.form-group {
+  margin-bottom: 20px;
+}
+
+.hirundo-text-input:focus,
+select.hirundo-text-input:focus {
+  outline: none;
+  border-color: #4299e1;
+  box-shadow: 0 0 0 2px #4299e1;
+}
+
+.form-group label.emberiza-label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: bold;
 }

--- a/preload.js
+++ b/preload.js
@@ -26,6 +26,15 @@ contextBridge.exposeInMainWorld('electron', {
   }
 });
 
+// Alias API for legacy code expecting `window.electronAPI`
+contextBridge.exposeInMainWorld('electronAPI', {
+  sendBrainstormingChat: (payload) => ipcRenderer.send('send-brainstorming-chat', payload),
+  onBrainstormingChatStreamChunk: (callback) => ipcRenderer.on('brainstorming-chat-stream-chunk', callback),
+  onBrainstormingChatStreamError: (callback) => ipcRenderer.on('brainstorming-chat-stream-error', callback),
+  onBrainstormingChatStreamEnd: (callback) => ipcRenderer.on('brainstorming-chat-stream-end', callback),
+  closeApp: () => ipcRenderer.send('close-window')
+});
+
 // Override global console methods
 const _log = console.log;
 const _warn = console.warn;


### PR DESCRIPTION
## Summary
- expose `electronAPI` helpers in preload so brainstorming chat can talk to Electron
- update console-message handler for Electron v36
- move scoped component styles into `roadrunner.css`
- document brainstorming fix steps

## Testing
- `npm install`
- `npm test` *(fails: Cannot find module 'simple-git', 'node-fetch' and Jest parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_684092387d3c8327b49e75893d6f8c1e