### PR TITLE
Add conversation serializer utility

### DIFF
--- a/Info/conversation_serializer.sniper.md
+++ b/Info/conversation_serializer.sniper.md
@@ -1,0 +1,4 @@
+# Conversation Serializer
+
+## Goal
+Provide a simple serializer for saving and loading conversation history used in the Brainstorming chat features.

--- a/Info/conversation_serializer.steps.md
+++ b/Info/conversation_serializer.steps.md
@@ -1,0 +1,3 @@
+- Added `conversationSerializer.js` with `Conversation` class and serialize/deserialize helpers.
+- Created matching Jest test `conversationSerializer.test.js`.
+- Documented new module in `conversation_serializer.sniper.md`.

--- a/frontend/src/conversationSerializer.js
+++ b/frontend/src/conversationSerializer.js
@@ -1,0 +1,22 @@
+// Simple Conversation and serializer utilities
+export default class Conversation {
+  constructor(id, messages = []) {
+    this.id = id;
+    this.messages = messages;
+  }
+
+  addMessage(role, text, timestamp = new Date().toISOString(), metadata = {}) {
+    this.messages.push({ role, text, timestamp, ...metadata });
+  }
+
+  // Serialize conversation to JSON string
+  serialize() {
+    return JSON.stringify({ id: this.id, messages: this.messages });
+  }
+
+  // Deserialize JSON string back to Conversation instance
+  static deserialize(jsonString) {
+    const data = JSON.parse(jsonString);
+    return new Conversation(data.id, data.messages || []);
+  }
+}

--- a/frontend/src/conversationSerializer.test.js
+++ b/frontend/src/conversationSerializer.test.js
@@ -1,0 +1,17 @@
+import Conversation from './conversationSerializer';
+
+describe('Conversation Serializer', () => {
+  it('serializes and deserializes conversation correctly', () => {
+    const convo = new Conversation('123');
+    convo.addMessage('user', 'Hello');
+    convo.addMessage('assistant', 'Hi there');
+
+    const serialized = convo.serialize();
+    const restored = Conversation.deserialize(serialized);
+
+    expect(restored.id).toBe('123');
+    expect(restored.messages.length).toBe(2);
+    expect(restored.messages[0].text).toBe('Hello');
+    expect(restored.messages[1].role).toBe('assistant');
+  });
+});

--- a/roadrunner.steps.md
+++ b/roadrunner.steps.md
@@ -207,3 +207,5 @@ Target Version: v1.3.0
 44. Removed inline CSS from `RoadrunnerExecutor.vue` and `App.vue`. Added matching
     utility classes in `src/styles/roadrunner.css` to comply with the new
     `AGENTS.md` guidelines.
+45. Added conversation serializer module for chat history.
+


### PR DESCRIPTION
## Summary
- add `Conversation` class to save and load chat history
- cover serializer with Jest tests
- document the module in `Info`
- log step in `roadrunner.steps.md`

## Testing
- `npx jest --runInBand --silent` *(fails: Jest could not run due to missing modules and syntax issues)*

------
https://chatgpt.com/codex/tasks/task_e_6840a8737e9483279e02cc5d410f810b