### PR TITLE
Fix: Replace this.$set with direct assignment in App.vue

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -366,19 +366,19 @@ export default {
     // Ensures essential properties (like modelConfig, annotations, lastStatus) exist on a task object.
     initializeTaskProperties(task) {
       if (!task.modelConfig || !task.modelConfig.id) {
-        this.$set(task, 'modelConfig', { ...this.defaultModelConfig });
+        task.modelConfig = { ...this.defaultModelConfig };
       }
       if (!task.modelConfigId) { // Used for v-model on select
-          this.$set(task, 'modelConfigId', task.modelConfig.id);
+          task.modelConfigId = task.modelConfig.id;
       }
       // ... (existing initializeAnnotations logic)
        if (task.steps && Array.isArray(task.steps)) {
           task.steps.forEach(step => {
             if (!step.hasOwnProperty('annotations') || !Array.isArray(step.annotations)) {
-              this.$set(step, 'annotations', []);
+              step.annotations = [];
             }
             if (!step.hasOwnProperty('lastStatus')) {
-              this.$set(step, 'lastStatus', 'not_run');
+              step.lastStatus = 'not_run';
             }
           });
         }


### PR DESCRIPTION
The `initializeTaskProperties` method in `frontend/src/App.vue` was using `this.$set` to add properties to task and step objects. In Vue 3, `this.$set` is no longer available and causes a TypeError.

This commit replaces the `this.$set` calls with direct property assignments, which is the correct way to ensure reactivity in Vue 3 for objects that are already reactive. This resolves the error "this.$set is not a function" that occurred during file upload on the Coder page.