### PR TITLE
Fix: Define getActiveTaskDescription method in App.vue

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -550,6 +550,13 @@ export default {
         this.$store.dispatch('updateOllamaStatus', { isConnected: false, message: 'Ollama Connection Failed. Many features will be disabled.' });
       }
     },
+
+    getActiveTaskDescription() {
+      if (this.activeSessionTaskDetails && this.activeSessionTaskDetails.task_description) {
+        return this.activeSessionTaskDetails.task_description;
+      }
+      return 'No active task';
+    },
     // ... (rest of methods: copyLog, exportLog, IPC handlers, etc.)
 
     // Sends the user's message from the Brainstorming tab to the main Electron process via IPC for LLM interaction.


### PR DESCRIPTION
The method getActiveTaskDescription was being called in the template of App.vue but was not defined in the component's methods. This caused a TypeError when the coder screen was active and a task was selected.

This commit defines the getActiveTaskDescription method in App.vue. The method returns the task_description of the activeSessionTaskDetails if available, otherwise returns 'No active task'.

This should resolve the TypeError and display the active task description correctly.