### PR TITLE
Fix: Prevent TypeError in task status display

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -126,7 +126,7 @@
                     <!-- Display Statistics -->
                     <div v-if="task.lastExecutionStats && task.lastExecutionStats.overallStatus !== 'not_run'" class="text-xs mt-1">
                       <span :class="['font-semibold', task.lastExecutionStats.overallStatus === 'success' ? 'text-green-400' : (task.lastExecutionStats.overallStatus === 'failure' ? 'text-red-400' : 'text-yellow-400')]">
-                        Status: {{ task.lastExecutionStats.overallStatus.replace('_', ' ') }}
+                        Status: {{ (task.lastExecutionStats.overallStatus || '').replace('_', ' ') }}
                       </span>
                       <span class="ml-2 text-gray-400">S: {{ task.lastExecutionStats.stepsSucceeded }}/{{ task.lastExecutionStats.stepsTotal }}</span>
                       <span v-if="task.lastExecutionStats.stepsFailed > 0" class="ml-1 text-red-400">F: {{ task.lastExecutionStats.stepsFailed }}</span>
@@ -427,7 +427,14 @@ export default {
             modelConfigId: this.defaultModelConfig.id,
             timestamp: new Date().toISOString(),
             status: 'defined',
-            lastExecutionStats: { /* ... initial stats ... */ },
+            lastExecutionStats: {
+                overallStatus: 'not_run',
+                stepsSucceeded: 0,
+                stepsTotal: (taskDetails.steps || []).length,
+                stepsFailed: 0,
+                stepsSkipped: 0,
+                logFile: null
+            },
         };
         this.initializeTaskProperties(newTask);
         this.sessionTasks.push(newTask);


### PR DESCRIPTION
The error 'Cannot read properties of undefined (reading 'replace')' occurred when rendering the task list, specifically when trying to call `.replace('_', ' ')` on `task.lastExecutionStats.overallStatus`.

This was caused by `overallStatus` not being initialized when new tasks were added to a session (e.g., via file upload), making it undefined.

This commit fixes the issue by:
1. Ensuring `lastExecutionStats.overallStatus` is initialized to 'not_run' within the `addTaskToSession` method in `App.vue`. Other related fields in `lastExecutionStats` (like `stepsSucceeded`, `stepsTotal`, etc.) are also initialized to sensible defaults.
2. Adding a defensive check in the template to use `(task.lastExecutionStats.overallStatus || '').replace('_', ' ')`. This provides an additional layer of safety, ensuring that `replace` is always called on a string.