### PR TITLE
Fix: Correct Ollama model type and brainstorming ID handling

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2618,6 +2618,14 @@ app.get('/api/ollama-models/categorized', async (req, res) => {
     const models = ollamaData.models || [];
     console.log(`${logPrefix} Extracted models array:`, models);
 
+    // === Add this loop ===
+    models.forEach(model => {
+      model.type = 'ollama'; // Add the type property
+      // Optionally, ensure model.id exists, similar to frontend, though frontend also does this.
+      // if (!model.id && model.model) model.id = model.model;
+    });
+    // === End of loop ===
+
     const categorizedModels = categorizeOllamaModels(models, modelCategories);
     console.log(`${logPrefix} Final categorized models being sent:`, categorizedModels);
     res.json(categorizedModels);


### PR DESCRIPTION
This commit addresses two issues related to Ollama model handling:

1. Model type undefined: I was not explicitly adding a 'type' field to model objects fetched from Ollama. This caused the frontend to show '(undefined)' for the model type during task execution. The `backend/server.js` has been updated to add `type: 'ollama'` to each model object from Ollama.

2. Unknown model ID for brainstorming: The Electron main process expected brainstorming model IDs for Ollama to be prefixed with 'ollama:' (e.g., 'ollama:llama2:latest'). However, the frontend was sending the plain model ID (e.g., 'llama2:latest'). The `frontend/src/App.vue` has been updated to check the model's type and prepend 'ollama:' to the ID before sending it for brainstorming if the type is 'ollama'.

These changes ensure consistent model type information in the frontend and correct model ID formatting for brainstorming requests to the main process.