### PR TITLE
feat: Enable conversational interaction for conference and brainstorm…

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -855,10 +855,21 @@ export default {
 
       console.log('[App.vue] sendBrainstormingMessage: Determined modelIdToSend:', modelIdToSend);
 
+      // Transform brainstormingHistory for the backend
+      const processedHistory = this.brainstormingHistory.map(message => {
+        return {
+          role: message.sender === 'user' ? 'user' : 'assistant',
+          content: message.text
+        };
+      });
+      // Note: The current user's message (messageText) is already included in brainstormingHistory
+      // before this transformation, so processedHistory will contain it as the last element.
+
       if (window.electronAPI && window.electronAPI.sendBrainstormingChat) {
         window.electronAPI.sendBrainstormingChat({
           modelId: modelIdToSend, // Use the adjusted modelId
-          prompt: messageText
+          // prompt: messageText, // Prompt is now part of the history
+          history: processedHistory
         });
       } else {
         console.error("electronAPI or sendBrainstormingChat not available.");

--- a/frontend/src/components/ConferenceTab.vue
+++ b/frontend/src/components/ConferenceTab.vue
@@ -45,7 +45,7 @@
       <label for="conference-prompt">Enter your prompt:</label>
       <textarea id="conference-prompt" v-model="prompt" rows="5" placeholder="e.g., What is the best strategy to reduce technical debt?"></textarea>
       <button @click="startConference" :disabled="isLoading || isStreaming">
-        {{ isLoading || isStreaming ? (isStreaming ? 'Streaming...' : 'Processing...') : 'Start Conference' }}
+        {{ isLoading || isStreaming ? (isStreaming ? 'Streaming...' : 'Processing...') : (conferenceLog.length === 0 ? 'Start Conference' : 'Send Message') }}
       </button>
     </div>
 


### PR DESCRIPTION
…ing agents

This commit introduces changes to allow for multi-turn conversations with the conference and brainstorming agents.

Conference Agent (`ConferenceTab.vue`):
- I modified the UI to change the 'Start Conference' button to 'Send Message' after your initial prompt.
- I ensured that your subsequent messages continue the existing conference, with the backend receiving the updated conversation history.

Brainstorming Agent (`App.vue`):
- I updated the `sendBrainstormingMessage` method to pass the complete `brainstormingHistory` (correctly formatted as an array of `{role, content}` objects) to the backend. This allows the brainstorming model to maintain context across multiple turns.

Backend (`electron.js`):
- I verified that the existing backend handlers for both agents already support receiving and utilizing conversation history. No backend changes were required.

These changes enhance the usability of the agents by allowing you to have more natural, iterative interactions rather than being limited to one-shot tasks.