### PR TITLE
Fix instructions modal showModal binding

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -247,7 +247,7 @@
 
         <!-- Conference Tab Content -->
         <div v-if="activeTab === 'conference'" class="tab-content conference-tab-content p-4">
-          <conference-tab />
+          <conference-tab @edit-instructions="openConferenceAgentInstructions" />
         </div>
 
         <!-- Configuration Tab Content -->
@@ -259,7 +259,7 @@
       <instructions-modal
         :agentType="modalAgentType"
         :agentRole="modalAgentRole"
-        :showModal.sync="showInstructionsModal"
+        v-model:showModal="showInstructionsModal"
       />
    </div>
 </template>
@@ -791,6 +791,11 @@ export default {
     openBrainstormingInstructions() {
       this.modalAgentType = 'brainstorming_agent';
       this.modalAgentRole = null;
+      this.showInstructionsModal = true;
+    },
+    openConferenceAgentInstructions(role) {
+      this.modalAgentType = 'conference_agent';
+      this.modalAgentRole = role;
       this.showInstructionsModal = true;
     },
 

--- a/frontend/src/components/ConferenceTab.vue
+++ b/frontend/src/components/ConferenceTab.vue
@@ -109,13 +109,8 @@
 </template>
 
 <script>
-import InstructionsModal from './InstructionsModal.vue'; // Import the modal
-
 export default {
   name: 'ConferenceTab',
-  components: {
-    InstructionsModal, // Register the modal
-  },
   data() {
     return {
       prompt: '',
@@ -130,9 +125,6 @@ export default {
       conversationHistory: [], // History sent to backend { role, content }
       logMessages: [],
       generalBackendLogs: [], // Added for general backend logs
-      // For Instructions Modal
-      showInstructionsModal: false,
-      modalAgentRoleForConference: null,
     };
   },
   computed: {
@@ -257,8 +249,7 @@ export default {
       }
     },
     openConferenceInstructions(role) {
-      this.modalAgentRoleForConference = role;
-      this.showInstructionsModal = true;
+      this.$emit('edit-instructions', role);
     },
     setDefaultModels() {
       console.log('[ConferenceTab setDefaultModels] Attempting to set default models.');

--- a/frontend/src/components/InstructionsModal.vue
+++ b/frontend/src/components/InstructionsModal.vue
@@ -50,6 +50,7 @@ export default {
       required: true,
     },
   },
+  emits: ['update:showModal'],
   data() {
     return {
       instructions: [],


### PR DESCRIPTION
## Summary
- wire up conference tab to emit when editing instructions
- switch InstructionsModal binding to Vue 3 `v-model:showModal`
- add event handler in App.vue for conference instructions
- declare emitted event in InstructionsModal

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e6742f908327b8d2b91bba8adb31