### PR TITLE
Fix duplicate var and handle unresolved templates

### DIFF
--- a/backend/fsAgent.js
+++ b/backend/fsAgent.js
@@ -73,6 +73,17 @@ class ModularFsAgent {
         }
       };
     }
+
+    if (/\{\{[^}]+\}\}/.test(relativePath)) {
+      return {
+        success: false,
+        error: {
+          code: 'FS_UNRESOLVED_TEMPLATE',
+          message: 'Error: Path contains unresolved template placeholders.',
+          details: { relativePath }
+        }
+      };
+    }
     const normalizedPath = path.normalize(relativePath);
     let fullPath = path.isAbsolute(normalizedPath)
       ? path.resolve(normalizedPath)

--- a/backend/tests/fsAgent.test.js
+++ b/backend/tests/fsAgent.test.js
@@ -73,6 +73,12 @@ describe('ModularFsAgent', () => {
             expect(result.success).toBe(false);
             expect(result.error.code).toBe('FS_RESOLVE_PATH_INVALID_TYPE');
         });
+
+        it('should return error for unresolved template placeholders', () => {
+            const result = fsAgentInstance.resolvePathInWorkspace('file_{{outputs.missing}}.txt');
+            expect(result.success).toBe(false);
+            expect(result.error.code).toBe('FS_UNRESOLVED_TEMPLATE');
+        });
     });
 
     describe('createFile', () => {

--- a/electron.js
+++ b/electron.js
@@ -416,7 +416,6 @@ ipcMain.on('start-conference-stream', (event, payload) => {
     console.log('[Electron IPC] start-conference-stream: EventSource connection opened.');
     // For onopen, the data is static, so we can log it directly here or ensure forwardEvent handles it.
     // To stick to the plan, ensure forwardEvent is called for all relevant events.
-    const openData = { type: 'log_entry', message: 'Connection to backend for conference established.', speaker: 'System' };
     // Log before sending (as per plan, though forwardEvent will log again)
     // console.log(`[Electron IPC] Forwarding to ConferenceTab - Channel: conference-stream-log-entry, Payload: ${JSON.stringify(openData)}`);
 


### PR DESCRIPTION
## Summary
- de-duplicate `openData` constant in `electron.js`
- detect unresolved `{{}}` templates in paths
- test new error path in fsAgent

## Testing
- `npm test` *(fails: Cannot find module 'node-mocks-http' and ESM parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_684205df73608327824c87f47a762670