### PR TITLE
Fix: Ensure correct error reporting for step failures on initial attempt

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1142,7 +1142,7 @@ async function executeStepsInternal(
     // This loop handles retries (simple or after refinement) for the current step.
     // It continues as long as the step hasn't succeeded and retry/refinement attempts are within limits.
     while (!stepProcessedSuccessfully &&
-           (currentStep._internalRetryCount < (currentStep.details?.maxRetries || 0)) ||
+           (currentStep._internalRetryCount <= (currentStep.details?.maxRetries || 0)) ||
            (currentStep.details?.onError === 'refine_and_retry' && currentStep._internalRefineCount < (currentStep.details?.maxRefinementRetries || 1))) { // Default 1 refinement attempt if not specified
 
       // Resolve templates just before each attempt, in case context changed due to refinement


### PR DESCRIPTION
This commit addresses an issue where failures on the initial attempt of a task step (when `maxRetries` is 0, the default) could lead to a generic "Unknown error" or "UNEXPECTED_ERROR_TYPE_IN_TRIGGER" instead of the specific error from the step's execution.

The root cause was that the main step execution logic was inside a `while` loop conditioned by `_internalRetryCount < maxRetries`. If `maxRetries` was 0, this loop would not execute even for the first attempt. Consequently, `lastErrorForStep` would remain `null`, and `triggerStepFailure` would be called with improper error details.

The fix involves changing the condition in the `while` loop in `executeStepsInternal` in `backend/server.js` from: `currentStep._internalRetryCount < (currentStep.details?.maxRetries || 0)` to:
`currentStep._internalRetryCount <= (currentStep.details?.maxRetries || 0)`

This ensures that the loop (and thus the step's primary execution logic within its `try...catch` block) runs at least once. If this initial attempt fails, `lastErrorForStep` is now correctly populated with an `Error` instance, allowing `triggerStepFailure` to report the specific error to you and logs.

This primarily resolves the issue observed with `createFile` steps failing due to path or permission issues on their first attempt and not showing the underlying cause.