### PR TITLE
Fix PostCSS config for ESM

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
-module.exports = {
+export default {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
-  }
+  },
 };


### PR DESCRIPTION
## Summary
- update `postcss.config.js` to support ESM export

## Testing
- `npm test` *(fails: Cannot find module 'cors' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68469d6710088327ab9c4881da7360b8