### PR TITLE
Fix API path

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -126,7 +126,7 @@
 <script>
 import { mapGetters, mapState } from 'vuex';
 
-import { fetchCategorizedModels } from '../services/api'; // Import the new service
+import { fetchCategorizedModels } from './services/api';
 import Executor from './executor';
 import ConfigurationTab from './components/ConfigurationTab.vue';
 import ConferenceTab from './components/ConferenceTab.vue';

--- a/roadrunner.steps.md
+++ b/roadrunner.steps.md
@@ -109,3 +109,4 @@ Target Version: **v1.3.0**
 - Added terminal-style conference log display per model in ConferenceTab
 - [x] Added SVG icon set and updated buttons
 - [x] Fixed service import path and migrated modal styles
+- [x] Corrected API service import in App.vue build


### PR DESCRIPTION
## Summary
- fix the import path to the API service in App.vue
- document the fix in roadrunner.steps.md

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c56e74a483279bec2b50f7521fce