### PR TITLE
Fix import path for API service

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -126,7 +126,7 @@
 <script>
 import { mapGetters, mapState } from 'vuex';
 
-import { fetchCategorizedModels } from '../services/api'; // Import the new service
+import { fetchCategorizedModels } from './services/api'; // Import the new service
 import Executor from './executor';
 import ConfigurationTab from './components/ConfigurationTab.vue';
 import ConferenceTab from './components/ConferenceTab.vue';


### PR DESCRIPTION
## Summary
- point `fetchCategorizedModels` import to the correct service path

## Testing
- `npm run test` *(fails: Cannot find module 'supertest' and other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68471cd638e08327a8ebe382e48f8b84