### PR TITLE
Fix: Resolve ESM imports, syntax error, and integrate BrainstormingTab

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -34,10 +34,7 @@ import { AgentExecutor, createOpenAIFunctionsAgent, createReactAgent } from "lan
 import { ChatPromptTemplate, HumanMessagePromptTemplate, MessagesPlaceholder } from '@langchain/core/prompts';
 // renderTextDescription is not directly used, but as part of agent creation - assuming it's pulled in by agents if needed.
 // import { renderTextDescription } from "@langchain/core/tools";
-import * as langchainMemory from "langchain/memory";
-const ConversationBufferWindowMemory = langchainMemory.ConversationBufferWindowMemory; // Explicit property access
-console.log('[DEBUG] langchainMemory module loaded. Keys:', Object.keys(langchainMemory));
-console.log('[DEBUG] ConversationBufferWindowMemory (after property access):', typeof ConversationBufferWindowMemory);
+import { ConversationBufferWindowMemory } from "langchain/memory"; // Direct named import
 
 // Import tools and custom error - adding .js extension
 import { ListDirectoryTool, CreateFileTool, ReadFileTool, UpdateFileTool, DeleteFileTool, CreateDirectoryTool, DeleteDirectoryTool } from './langchain_tools/fs_tools.js';

--- a/electron.js
+++ b/electron.js
@@ -166,7 +166,7 @@ function createWindow() {
   }
 }
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
   app.commandLine.appendSwitch('disable-features', 'AutofillServerCommunication,AutofillCreditCard,AutofillProfile');
 
   session.defaultSession.webRequest.onHeadersReceived((details, callback) => {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -87,7 +87,7 @@
         </div>
 
         <div v-if="activeTab === 'brainstorming'" class="tab-content brainstorming-tab-content p-4 flex flex-col space-y-4">
-          <p class="text-gray-400 text-center">Brainstorming chat feature coming soon!</p>
+          <brainstorming-tab />
         </div>
 
         <div v-if="activeTab === 'conference'" class="tab-content conference-tab-content p-4">
@@ -126,7 +126,7 @@
 <script>
 import { mapGetters, mapState } from 'vuex';
 
-import { fetchCategorizedModels } from './services/api'; // Import the new service
+import { fetchCategorizedModels } from './services/api.js'; // Import the new service
 import Executor from './executor';
 import ConfigurationTab from './components/ConfigurationTab.vue';
 import ConferenceTab from './components/ConferenceTab.vue';


### PR DESCRIPTION
This commit addresses several issues related to the ES Modules refactor:

1.  **Backend Langchain ESM Import:**
    *   I corrected the import for `ConversationBufferWindowMemory` in `backend/server.js` to use a direct named import (`import { ConversationBufferWindowMemory } from "langchain/memory";`). This resolves potential "not a constructor" errors.

2.  **Frontend Vite Import Path:**
    *   I modified the import for `fetchCategorizedModels` in `frontend/src/App.vue` to be explicit: `import { fetchCategorizedModels } from './services/api.js';`.

3.  **Electron Syntax Error:**
    *   I fixed a `SyntaxError: Unexpected token ')'` in `electron.js` by making the `app.whenReady().then()` callback `async` to correctly support the `await startBackendServer()` call.

4.  **Brainstorming Tab Integration:**
    *   I replaced the placeholder text in `frontend/src/App.vue` with the `<brainstorming-tab />` component, enabling its UI. The `BrainstormingTab.vue` component itself was found to be substantially implemented.

**Verification Limitations:**
Due to timeouts I encountered during `npm install` (for root, frontend, and backend) and `npm run build` (frontend), I could not perform full end-to-end testing and verification of the application's stability and complete functionality (especially the Brainstorming Tab's SSE communication). The fixes are based on code analysis and direct error resolution. I recommend further testing in a local or less constrained environment.