### PR TITLE
Fix ReAct agent prompt

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -109,6 +109,8 @@ Assistant has access to the following tools and MUST use them when needed. Each 
 
 {tools}
 
+The tool names are: {tool_names}
+
 RESPONSE FORMAT INSTRUCTIONS:
 ----------------------------
 When responding to me, please output a response in one of two formats:


### PR DESCRIPTION
## Summary
- include missing `tool_names` placeholder in ReAct prompt so initialization succeeds

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486261e6788327aa4d015517c16599