### PR TITLE
Fix backend startup promise

### DIFF
--- a/electron.js
+++ b/electron.js
@@ -122,6 +122,7 @@ function startBackendServer() {
   // No specific action needed on 'exit' after portReceived for the Promise itself,
   // but logging and status updates are good.
   // backendProcess.on('exit', (code, signal) => { ... }); already handled above
+  });
 }
 
 function sendToAllWindows(channel, payload) {


### PR DESCRIPTION
## Summary
- close the `startBackendServer` promise properly in `electron.js`

## Testing
- `npm test` *(fails: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_684ca71d37988327813b017a54aff7a5